### PR TITLE
Support TLS 1.3, removed abandoned PayPal endpoint

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: strangerstudios
 Tags: security, ecommerce, gateway, paypal, tls, server, php, api, version, curl, sslversion
 Requires at least: 3.0
-Tested up to: 5.2.2
-Stable tag: 1.0.1
+Tested up to: 5.7.0
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,8 +15,7 @@ Payment gateways are now requiring commmunication via TLS 1.2. This plugin will 
 
 If your server is not able to communicate via TLS 1.2, you will be shown the appropriate steps to take to upgrade the server version of OpenSSL, PHP, or direct you to update the SSLVERSION of CURL.
 
-The plugin currently offers testing via these API Endpoints:
-* PayPal (https://tlstest.paypal.com/)
+The plugin currently offers testing via the following API Endpoint:
 * How's My SSL? (https://www.howsmyssl.com/a/check)
 
 Testing against these API Endpoints should validate compatibility for other gateways and APIs, even if you are not using PayPal, for example, on your ecommerce application. However, we do plan to add more tests for API Endpoints provided by popular gateways.
@@ -38,6 +37,10 @@ None yet.
 1. Admin page under Tools > TLS 1.2 Test.
 
 == Changelog ==
+= 1.0.2 =
+* Show passing result if TLS 1.3 is enabled
+* Removed abandoned PayPal endpoint
+
 = 1.0.1 =
 * Added cURL version to the table with notes to upgrade if below 7.34.0.
 * Improved recommendations in the notes section.

--- a/tls-1-2-compatibility-test.php
+++ b/tls-1-2-compatibility-test.php
@@ -3,7 +3,7 @@
 Plugin Name: TLS 1.2 Compatibility Test
 Plugin URI: http://www.paidmembershipspro.com
 Description: Verify TLS 1.2 support for included API endpoints and diagnose a solution to enable compatibility.
-Version: 1.0.1
+Version: 1.0.2
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 Text Domain: tls12
@@ -41,7 +41,7 @@ add_action('http_api_curl', 'tls12ct_http_api_curl');
 function tls12ct_getEndPoints() {
 	return array(
 		//id => array(label, endpoint, callback handler)
-		'paypal'=>array('name'=>'paypal', 'label'=>'PayPal', 'url'=>'https://tlstest.paypal.com/', 'callback'=>'tls12ct_test_paypal'),
+		//'paypal'=>array('name'=>'paypal', 'label'=>'PayPal', 'url'=>'https://tlstest.paypal.com/', 'callback'=>'tls12ct_test_paypal'),
 		//'google'=>array('name'=>'google', 'label'=>'Google', 'url'=>'https://cert-test.sandbox.google.com/', 'callback'=>'tls12ct_test_google'),
 		'howsmyssl'=>array('name'=>'howsmyssl', 'label'=>"How's My SSL?", 'url'=>'https://www.howsmyssl.com/a/check', 'callback'=>'tls12ct_test_howsmyssl'),		
 		
@@ -94,10 +94,13 @@ function tls12ct_test_howsmyssl($result) {
 	
 	if($result['tls_version'] == 'TLS 1.2') {
 		$enabled = true;
-		$message = 'TLS 1.2 enabled.';
+		$message = 'TLS 1.3 enabled';
+	} elseif($result['tls_version'] == 'TLS 1.2') {
+		$enabled = true;
+		$message = 'TLS 1.2 enabled';
 	} else {
 		$enabled = false;	
-		$message = 'TLS 1.2 not enabled.';
+		$message = 'TLS 1.2 not enabled';
 	}
 		
 	return array('enabled'=>$enabled, 'message'=>$message);
@@ -150,7 +153,7 @@ function tls12ct_tests_page() {
 						<h3 class="hndle"><?php printf(__('Test Results Using %s Endpoint', 'tls12ct'), $endpoints[$tls12ct_endpoint]['label']); ?></h3>
 						<div class="inside">
 							<?php if($tls12['enabled']) { ?>
-								<h1 style="color: green"><?php _e('TLS 1.2 Enabled', 'tls12ct');?></h1>
+								<h1 style="color: green"><?php _e($tls12['message'], 'tls12ct');?></h1>
 								<p><?php _e('Your site should work fine when making calls to gateways and APIs that require TLS 1.2. You may still want to consider the actions below to secure your site as much as possible.', 'tls12ct');?></p>
 							<?php } else { ?>
 								<h1 style="color: red"><?php _e('TLS 1.2 Not Enabled', 'tls12ct');?></h1>
@@ -171,9 +174,9 @@ function tls12ct_tests_page() {
 									<td>
 										<?php 
 											if($tls12['enabled'])
-												echo '<span style="color: green;">' . $tls12['message'] . '</span>';
+												echo '<span style="color: green;">' . $tls12['message'] . '.</span>';
 											else
-												echo '<strong style="color: red;">' . $tls12['message'] . '</strong>';
+												echo '<strong style="color: red;">' . $tls12['message'] . '.</strong>';
 										?>
 									</td>
 								</tr>
@@ -260,7 +263,7 @@ function tls12ct_tests_page() {
 											}
 										?>
 									</select>
-									<span class="description"><?php _e('If the PayPal test works, you should be able to connect to other gateway APIs as well.', 'tls12ct'); ?></span>
+									<span class="description"><?php // _e('If the PayPal test works, you should be able to connect to other gateway APIs as well.', 'tls12ct'); ?></span>
 								</td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
👋 Jason / Kim,

You probably don't remember me but we met briefly at WordCamp Lehigh Valley a few years ago.

I came across this plugin upon recommendation by Postmark as they're shutting off TLS 1.0 access next month.

I came across two small issues and patched them up in this PR.

1. If your server has TLS 1.3, the check fails
2. The PayPal endpoint is abandoned

I also confirmed compatibility with a clean install of WordPress 5.7.

Thanks for your work on this! Definitely saved me some time last week when I got emails from clients asking if they needed to do anything in response to Postmark's change.

Tyler